### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-lint.yml
+++ b/.github/workflows/build-lint.yml
@@ -1,5 +1,8 @@
 name: Build and Lint
 
+permissions:
+    contents: read
+
 on:
     push:
         branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Fx64b/learn/security/code-scanning/2](https://github.com/Fx64b/learn/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the steps in the workflow, it primarily needs read access to the repository contents and possibly write access to pull requests if it interacts with them. However, since there is no explicit interaction with pull requests in the provided steps, we will start with `contents: read` as the minimal permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
