### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: Release
 on:
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
     release:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Fx64b/learn/security/code-scanning/1](https://github.com/Fx64b/learn/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the operations performed in the workflow, the following permissions are appropriate:
- `contents: read` for accessing repository files.
- `pull-requests: write` for interacting with pull requests, if necessary.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `release` job. In this case, adding it at the root level is recommended for simplicity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
