### PR TITLE
Check email signup rate limit configuration

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -31,7 +31,10 @@ export const authOptions: NextAuthOptions = {
             }) => {
                 const t = await getTranslations('auth')
 
-                const rateLimitResult = await checkRateLimit(`email:${email}`)
+                const rateLimitResult = await checkRateLimit(
+                    `email:${email}`,
+                    'email'
+                )
 
                 if (!rateLimitResult.success) {
                     throw new Error(t('ratelimitExceeded'))


### PR DESCRIPTION
The checkRateLimit call was missing the 'email' type parameter, causing it to default to 'general' (100/hour) instead of 'email' (5/15min). This allowed excessive email sends during signup.