### PR TITLE
Add badge-based tag input for deck categories

### DIFF
--- a/__tests__/lib/category-parser.test.ts
+++ b/__tests__/lib/category-parser.test.ts
@@ -1,0 +1,116 @@
+import { parseCategoryToTags } from '@/lib/category-parser'
+import { describe, expect, it } from 'vitest'
+
+describe('parseCategoryToTags', () => {
+    describe('JSON array format (new format)', () => {
+        it('should parse valid JSON array', () => {
+            const result = parseCategoryToTags('["Math","Science","History"]')
+            expect(result).toEqual(['Math', 'Science', 'History'])
+        })
+
+        it('should trim whitespace from JSON array values', () => {
+            const result = parseCategoryToTags(
+                '["  Math  "," Science ","History  "]'
+            )
+            expect(result).toEqual(['Math', 'Science', 'History'])
+        })
+
+        it('should filter empty strings from JSON array', () => {
+            const result = parseCategoryToTags(
+                '["Math","","Science","  ","History"]'
+            )
+            expect(result).toEqual(['Math', 'Science', 'History'])
+        })
+
+        it('should handle empty JSON array', () => {
+            const result = parseCategoryToTags('[]')
+            expect(result).toEqual([])
+        })
+    })
+
+    describe('Comma-separated format (legacy)', () => {
+        it('should parse comma-separated values', () => {
+            const result = parseCategoryToTags('Math, Science, History')
+            expect(result).toEqual(['Math', 'Science', 'History'])
+        })
+
+        it('should trim whitespace from comma-separated values', () => {
+            const result = parseCategoryToTags(
+                '  Math  ,  Science  ,  History  '
+            )
+            expect(result).toEqual(['Math', 'Science', 'History'])
+        })
+
+        it('should handle comma-separated without spaces', () => {
+            const result = parseCategoryToTags('Math,Science,History')
+            expect(result).toEqual(['Math', 'Science', 'History'])
+        })
+
+        it('should filter empty values from comma-separated', () => {
+            const result = parseCategoryToTags('Math, , Science,  , History')
+            expect(result).toEqual(['Math', 'Science', 'History'])
+        })
+    })
+
+    describe('Space-separated format (legacy)', () => {
+        it('should parse space-separated values', () => {
+            const result = parseCategoryToTags('Math Science History')
+            expect(result).toEqual(['Math', 'Science', 'History'])
+        })
+
+        it('should handle multiple spaces between values', () => {
+            const result = parseCategoryToTags('Math   Science    History')
+            expect(result).toEqual(['Math', 'Science', 'History'])
+        })
+
+        it('should filter empty values from space-separated', () => {
+            const result = parseCategoryToTags('Math  Science   History')
+            expect(result).toEqual(['Math', 'Science', 'History'])
+        })
+    })
+
+    describe('Single value format (legacy)', () => {
+        it('should handle single value', () => {
+            const result = parseCategoryToTags('Mathematics')
+            expect(result).toEqual(['Mathematics'])
+        })
+
+        it('should trim whitespace from single value', () => {
+            const result = parseCategoryToTags('  Mathematics  ')
+            expect(result).toEqual(['Mathematics'])
+        })
+
+        it('should handle empty string', () => {
+            const result = parseCategoryToTags('')
+            expect(result).toEqual([])
+        })
+
+        it('should handle whitespace-only string', () => {
+            const result = parseCategoryToTags('   ')
+            expect(result).toEqual([])
+        })
+    })
+
+    describe('Edge cases', () => {
+        it('should prioritize comma over space separation', () => {
+            const result = parseCategoryToTags('Math Science, History Physics')
+            expect(result).toEqual(['Math Science', 'History Physics'])
+        })
+
+        it('should handle tags with multiple words when comma-separated', () => {
+            const result = parseCategoryToTags(
+                'Computer Science, Machine Learning, Data Analysis'
+            )
+            expect(result).toEqual([
+                'Computer Science',
+                'Machine Learning',
+                'Data Analysis',
+            ])
+        })
+
+        it('should not split single multi-word category without comma or leading space', () => {
+            const result = parseCategoryToTags('ComputerScience')
+            expect(result).toEqual(['ComputerScience'])
+        })
+    })
+})

--- a/app/deck/[id]/edit/deck-details-form.tsx
+++ b/app/deck/[id]/edit/deck-details-form.tsx
@@ -56,6 +56,7 @@ import {
     PopoverContent,
     PopoverTrigger,
 } from '@/components/ui/popover'
+import { TagInput } from '@/components/ui/tag-input'
 import { Textarea } from '@/components/ui/textarea'
 
 interface DeckDetailsFormProps {
@@ -79,11 +80,21 @@ export default function DeckDetailsForm({ deck }: DeckDetailsFormProps) {
     const [isExportDialogOpen, setIsExportDialogOpen] = useState(false)
     const [isCopied, setIsCopied] = useState(false)
     const [isLoadingExport, setIsLoadingExport] = useState(false)
+    // Parse category from JSON string to array, fallback to single value for backward compatibility
+    const parseTags = (category: string): string[] => {
+        try {
+            const parsed = JSON.parse(category)
+            return Array.isArray(parsed) ? parsed : [category]
+        } catch {
+            return [category]
+        }
+    }
+
     const [formData, setFormData] = useState({
         id: deck.id,
         title: deck.title,
         description: deck.description || '',
-        category: deck.category,
+        tags: parseTags(deck.category),
         activeUntil: fromUTCDateOnly(deck.activeUntil),
     })
 
@@ -97,7 +108,8 @@ export default function DeckDetailsForm({ deck }: DeckDetailsFormProps) {
         formDataToSend.append('id', formData.id)
         formDataToSend.append('title', formData.title)
         formDataToSend.append('description', formData.description)
-        formDataToSend.append('category', formData.category)
+        // Store tags as JSON array in category field
+        formDataToSend.append('category', JSON.stringify(formData.tags))
 
         if (formData.activeUntil) {
             // Convert to UTC date-only before sending
@@ -250,18 +262,17 @@ export default function DeckDetailsForm({ deck }: DeckDetailsFormProps) {
                                     {t('categoryRequired')}{' '}
                                     <span className="text-red-500">*</span>
                                 </Label>
-                                <Input
+                                <TagInput
                                     id="category"
-                                    value={formData.category}
-                                    onChange={(e) =>
+                                    tags={formData.tags}
+                                    onChange={(tags) =>
                                         setFormData((prev) => ({
                                             ...prev,
-                                            category: e.target.value,
+                                            tags,
                                         }))
                                     }
                                     placeholder={t('categoryPlaceholder')}
                                     required
-                                    className="transition-all focus-visible:ring-offset-2"
                                 />
                             </div>
 

--- a/app/deck/[id]/edit/deck-details-form.tsx
+++ b/app/deck/[id]/edit/deck-details-form.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { parseCategoryToTags } from '@/lib/category-parser'
 import { fromUTCDateOnly, toUTCDateOnly } from '@/lib/date'
 import { cn } from '@/lib/utils'
 import type { DeckType } from '@/types'
@@ -80,21 +81,11 @@ export default function DeckDetailsForm({ deck }: DeckDetailsFormProps) {
     const [isExportDialogOpen, setIsExportDialogOpen] = useState(false)
     const [isCopied, setIsCopied] = useState(false)
     const [isLoadingExport, setIsLoadingExport] = useState(false)
-    // Parse category from JSON string to array, fallback to single value for backward compatibility
-    const parseTags = (category: string): string[] => {
-        try {
-            const parsed = JSON.parse(category)
-            return Array.isArray(parsed) ? parsed : [category]
-        } catch {
-            return [category]
-        }
-    }
-
     const [formData, setFormData] = useState({
         id: deck.id,
         title: deck.title,
         description: deck.description || '',
-        tags: parseTags(deck.category),
+        tags: parseCategoryToTags(deck.category),
         activeUntil: fromUTCDateOnly(deck.activeUntil),
     })
 

--- a/app/deck/create/page.tsx
+++ b/app/deck/create/page.tsx
@@ -24,6 +24,7 @@ import {
     PopoverContent,
     PopoverTrigger,
 } from '@/components/ui/popover'
+import { TagInput } from '@/components/ui/tag-input'
 
 export default function CreateDeckPage() {
     const router = useRouter()
@@ -34,7 +35,7 @@ export default function CreateDeckPage() {
     const [formData, setFormData] = useState({
         title: '',
         description: '',
-        category: '',
+        tags: [] as string[],
         activeUntil: null as Date | null,
     })
 
@@ -45,7 +46,8 @@ export default function CreateDeckPage() {
         const formDataToSend = new FormData()
         formDataToSend.append('title', formData.title)
         formDataToSend.append('description', formData.description)
-        formDataToSend.append('category', formData.category)
+        // Store tags as JSON array in category field
+        formDataToSend.append('category', JSON.stringify(formData.tags))
 
         if (formData.activeUntil) {
             const utcDate = toUTCDateOnly(formData.activeUntil)
@@ -123,13 +125,13 @@ export default function CreateDeckPage() {
                             <Label htmlFor="category">
                                 {t('categoryLabel')}
                             </Label>
-                            <Input
+                            <TagInput
                                 id="category"
-                                value={formData.category}
-                                onChange={(e) =>
+                                tags={formData.tags}
+                                onChange={(tags) =>
                                     setFormData((prev) => ({
                                         ...prev,
-                                        category: e.target.value,
+                                        tags,
                                     }))
                                 }
                                 placeholder={t('categoryPlaceholder')}

--- a/components/flashcards/deck-card.tsx
+++ b/components/flashcards/deck-card.tsx
@@ -6,6 +6,7 @@ import { AlertTriangle, PencilIcon } from 'lucide-react'
 import { getTranslations } from 'next-intl/server'
 import Link from 'next/link'
 
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
     Card,
@@ -36,6 +37,18 @@ export async function DeckCard({
     isPastDue = false,
 }: DeckCardProps) {
     const t = await getTranslations()
+
+    // Parse tags from category field (supports both JSON array and legacy single string)
+    const parseTags = (category: string): string[] => {
+        try {
+            const parsed = JSON.parse(category)
+            return Array.isArray(parsed) ? parsed : [category]
+        } catch {
+            return [category]
+        }
+    }
+
+    const tags = parseTags(deck.category)
 
     return (
         <Card
@@ -86,6 +99,15 @@ export async function DeckCard({
                         </div>
                     )}
                 </CardDescription>
+                {tags.length > 0 && (
+                    <div className="mt-2 flex flex-wrap gap-1">
+                        {tags.map((tag) => (
+                            <Badge key={tag} variant="secondary">
+                                {tag}
+                            </Badge>
+                        ))}
+                    </div>
+                )}
             </CardHeader>
             <CardContent className="mt-auto pb-2">
                 <div className="space-y-1">

--- a/components/flashcards/deck-card.tsx
+++ b/components/flashcards/deck-card.tsx
@@ -1,3 +1,4 @@
+import { parseCategoryToTags } from '@/lib/category-parser'
 import { fromUTCDateOnly } from '@/lib/date'
 import { DeckType } from '@/types'
 import { format } from 'date-fns'
@@ -38,17 +39,7 @@ export async function DeckCard({
 }: DeckCardProps) {
     const t = await getTranslations()
 
-    // Parse tags from category field (supports both JSON array and legacy single string)
-    const parseTags = (category: string): string[] => {
-        try {
-            const parsed = JSON.parse(category)
-            return Array.isArray(parsed) ? parsed : [category]
-        } catch {
-            return [category]
-        }
-    }
-
-    const tags = parseTags(deck.category)
+    const tags = parseCategoryToTags(deck.category)
 
     return (
         <Card

--- a/components/ui/tag-input.tsx
+++ b/components/ui/tag-input.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import { X } from 'lucide-react'
+
+import type React from 'react'
+import { type KeyboardEvent, useRef, useState } from 'react'
+
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+
+interface TagInputProps {
+    tags: string[]
+    onChange: (tags: string[]) => void
+    placeholder?: string
+    id?: string
+    required?: boolean
+}
+
+export function TagInput({
+    tags,
+    onChange,
+    placeholder,
+    id,
+    required = false,
+}: TagInputProps) {
+    const [inputValue, setInputValue] = useState('')
+    const inputRef = useRef<HTMLInputElement>(null)
+
+    const addTag = (tag: string) => {
+        const trimmedTag = tag.trim()
+        if (trimmedTag && !tags.includes(trimmedTag)) {
+            onChange([...tags, trimmedTag])
+        }
+        setInputValue('')
+    }
+
+    const removeTag = (tagToRemove: string) => {
+        onChange(tags.filter((tag) => tag !== tagToRemove))
+    }
+
+    const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+        // Check for Enter, Space, or Comma
+        if (e.key === 'Enter' || e.key === ' ' || e.key === ',') {
+            e.preventDefault()
+            addTag(inputValue)
+        } else if (
+            e.key === 'Backspace' &&
+            inputValue === '' &&
+            tags.length > 0
+        ) {
+            // Remove last tag when backspace is pressed on empty input
+            removeTag(tags[tags.length - 1])
+        }
+    }
+
+    const handleBlur = () => {
+        // Add tag on blur if there's text in the input
+        if (inputValue.trim()) {
+            addTag(inputValue)
+        }
+    }
+
+    return (
+        <div
+            className="border-input bg-background ring-offset-background focus-within:ring-ring flex min-h-[40px] w-full flex-wrap items-center gap-2 rounded-md border px-3 py-2 text-base focus-within:ring-2 focus-within:ring-offset-2 focus-within:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+            onClick={() => inputRef.current?.focus()}
+        >
+            {tags.map((tag) => (
+                <Badge
+                    key={tag}
+                    variant="secondary"
+                    className="gap-1 pr-1 pl-2"
+                >
+                    {tag}
+                    <button
+                        type="button"
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            removeTag(tag)
+                        }}
+                        className="hover:bg-secondary-foreground/20 ml-1 rounded-sm"
+                    >
+                        <X className="h-3 w-3" />
+                        <span className="sr-only">Remove {tag}</span>
+                    </button>
+                </Badge>
+            ))}
+            <Input
+                ref={inputRef}
+                id={id}
+                type="text"
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onBlur={handleBlur}
+                placeholder={tags.length === 0 ? placeholder : ''}
+                className="h-7 flex-1 border-0 bg-transparent p-0 shadow-none ring-0 outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                required={required && tags.length === 0}
+            />
+        </div>
+    )
+}

--- a/lib/category-parser.ts
+++ b/lib/category-parser.ts
@@ -1,0 +1,35 @@
+/**
+ * Parse category field to tags array, supporting multiple legacy formats
+ * @param category - The category string from database
+ * @returns Array of tag strings
+ */
+export function parseCategoryToTags(category: string): string[] {
+    // Try to parse as JSON array first (new format)
+    try {
+        const parsed = JSON.parse(category)
+        if (Array.isArray(parsed)) {
+            return parsed.filter((tag) => tag.trim()).map((tag) => tag.trim())
+        }
+    } catch {
+        // Not JSON, continue to legacy format parsing
+    }
+
+    // Check for comma-separated values (legacy format)
+    if (category.includes(',')) {
+        return category
+            .split(',')
+            .map((tag) => tag.trim())
+            .filter((tag) => tag)
+    }
+
+    // Check for space-separated values (legacy format)
+    if (category.includes(' ')) {
+        return category
+            .split(' ')
+            .map((tag) => tag.trim())
+            .filter((tag) => tag)
+    }
+
+    // Single value (legacy format)
+    return [category.trim()].filter((tag) => tag)
+}


### PR DESCRIPTION
Implement a tag input component that creates badges when users press Enter, Space, or Comma keys. This replaces the single category text field with a multi-tag system that:

- Creates badges on Enter, Space, or Comma keypress
- Allows removing tags by clicking the X button
- Stores tags as JSON array in the category field for backward compatibility
- Displays tags as badges on deck cards
- Supports legacy single-category decks by parsing them as single-tag arrays

Changes:
- Add new TagInput component using shadcn badges
- Update deck creation form to use TagInput
- Update deck edit form to use TagInput with tag parsing
- Update deck card to display category tags as badges