### PR TITLE
Upgrade AI model to Gemini 3.1 Flash-Lite with optimized tokens

### DIFF
--- a/app/actions/ai-flashcards.ts
+++ b/app/actions/ai-flashcards.ts
@@ -21,6 +21,13 @@ const MAX_CARDS_PER_GENERATION = 55
 const MAX_DOCUMENT_LENGTH = 50000
 const PDF_PARSING_TIMEOUT = 30000
 
+// Gemini 3.1 Flash-Lite: cheapest generally-available model that still supports
+// structured output. Defaults to `minimal` thinking, so latency/cost stay low.
+const AI_MODEL = 'gemini-3.1-flash-lite'
+// Thinking tokens count against the output budget, so leave headroom above the
+// ~4k tokens a full generation of cards actually needs.
+const AI_MAX_OUTPUT_TOKENS = 8192
+
 // Schemas
 const flashcardSchema = z.object({
     flashcards: z
@@ -507,12 +514,13 @@ export async function generateAIFlashcardsUnified(
 
         try {
             const { object } = await generateObject({
-                model: google('gemini-1.5-flash'),
+                model: google(AI_MODEL),
                 schema: flashcardSchema,
                 system: buildSystemPrompt(),
                 prompt: buildUserPrompt(sanitizedPrompt, documentContent),
-                temperature: 0.7,
-                maxTokens: 4000,
+                // Gemini 3 models are tuned for their default temperature of 1;
+                // lowering it degrades output, so it is intentionally not set.
+                maxTokens: AI_MAX_OUTPUT_TOKENS,
             })
 
             onProgress?.(


### PR DESCRIPTION
## Summary

Upgrades the AI flashcard generation to use Google's more cost-effective Gemini 3.1 Flash-Lite model while optimizing token allocation for better performance and cost efficiency.

## Key Changes

- **Model upgrade**: Switched from `gemini-1.5-flash` to `gemini-3.1-flash-lite`, the cheapest generally-available model that supports structured output
- **Token optimization**: Increased `maxTokens` from 4000 to 8192 to account for thinking tokens that count against the output budget, providing headroom above the ~4k tokens needed for a full card generation
- **Temperature tuning**: Removed explicit `temperature: 0.7` setting since Gemini 3 models are tuned for their default temperature of 1.0; lowering it degrades output quality
- **Configuration constants**: Extracted model name and max output tokens to named constants for better maintainability

## Implementation Details

The Gemini 3.1 Flash-Lite model defaults to `minimal` thinking mode, keeping latency and costs low while maintaining structured output capability. The increased token budget ensures thinking tokens don't constrain the actual flashcard generation output, which typically requires around 4k tokens.

https://claude.ai/code/session_019w2vhz3Quf8vRDacUrQ7uX